### PR TITLE
Fixes to get fds compiling and running on Mac OS 10.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TARGET    = fds
 CPPOBJS   = main.o spi.o fds.o device.o os.o
 ifeq ($(UNAME),Darwin)
  COBJS    = hidapi/hid-mac.o
- LIBS     = -framework IOKit -framework CoreFoundation
+ LIBS     = -framework IOKit -framework CoreFoundation -liconv
 endif
 ifeq ($(UNAME),Linux)
  COBJS    = hidapi/hid-linux.o

--- a/fds.cpp
+++ b/fds.cpp
@@ -27,7 +27,7 @@ enum {
 };
 
 
-void raw03_to_bin(uint8_t *raw, int rawSize, uint8_t **_bin, int *_binSize);
+static void raw03_to_bin(uint8_t *raw, int rawSize, uint8_t **_bin, int *_binSize);
 
 
 //don't include gap end
@@ -234,7 +234,6 @@ bool FDS_readDisk(char *filename_raw, char *filename_bin, char *filename_fds) {
     uint8_t *readBuf=NULL;
     int result;
     int bytesIn=0;
-    uint8_t sequence=1;
 
     //if(!(dev_readIO()&MEDIA_SET)) {
     //    printf("Warning - Disk not inserted?\n");

--- a/hidapi/hid-mac.c
+++ b/hidapi/hid-mac.c
@@ -1,17 +1,17 @@
 /*******************************************************
  HIDAPI - Multi-Platform library for
  communication with HID devices.
- 
+
  Alan Ott
  Signal 11 Software
 
  2010-07-03
 
  Copyright 2010, All Rights Reserved.
- 
+
  At the discretion of the user of this library,
  this software may be licensed under the terms of the
- GNU Public License v3, a BSD-Style license, or the
+ GNU General Public License v3, a BSD-Style license, or the
  original HIDAPI license as outlined in the LICENSE.txt,
  LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
  files located at the root of the source distribution.
@@ -51,7 +51,7 @@ static int pthread_barrier_init(pthread_barrier_t *barrier, const pthread_barrie
 		errno = EINVAL;
 		return -1;
 	}
-	
+
 	if(pthread_mutex_init(&barrier->mutex, 0) < 0) {
 		return -1;
 	}
@@ -118,15 +118,7 @@ struct hid_device_ {
 	pthread_barrier_t barrier; /* Ensures correct startup sequence */
 	pthread_barrier_t shutdown_barrier; /* Ensures correct shutdown sequence */
 	int shutdown_thread;
-	
-	hid_device *next;
 };
-
-/* Static list of all the devices open. This way when a device gets
-   disconnected, its hid_device structure can be marked as disconnected
-   from hid_device_removal_callback(). */
-static hid_device *device_list = NULL;
-static pthread_mutex_t device_list_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static hid_device *new_hid_device(void)
 {
@@ -141,30 +133,13 @@ static hid_device *new_hid_device(void)
 	dev->input_report_buf = NULL;
 	dev->input_reports = NULL;
 	dev->shutdown_thread = 0;
-	dev->next = NULL;
 
 	/* Thread objects */
 	pthread_mutex_init(&dev->mutex, NULL);
 	pthread_cond_init(&dev->condition, NULL);
 	pthread_barrier_init(&dev->barrier, NULL, 2);
 	pthread_barrier_init(&dev->shutdown_barrier, NULL, 2);
-	
-	/* Add the new record to the device_list. */
-	pthread_mutex_lock(&device_list_mutex);
-	if (!device_list)
-		device_list = dev;
-	else {
-		hid_device *d = device_list;
-		while (d) {
-			if (!d->next) {
-				d->next = dev;
-				break;
-			}
-			d = d->next;
-		}
-	}
-	pthread_mutex_unlock(&device_list_mutex);
-	
+
 	return dev;
 }
 
@@ -172,7 +147,7 @@ static void free_hid_device(hid_device *dev)
 {
 	if (!dev)
 		return;
-	
+
 	/* Delete any input reports still left over. */
 	struct input_report *rpt = dev->input_reports;
 	while (rpt) {
@@ -197,29 +172,11 @@ static void free_hid_device(hid_device *dev)
 	pthread_cond_destroy(&dev->condition);
 	pthread_mutex_destroy(&dev->mutex);
 
-	/* Remove it from the device list. */
-	pthread_mutex_lock(&device_list_mutex);
-	hid_device *d = device_list;
-	if (d == dev) {
-		device_list = d->next;
-	}
-	else {
-		while (d) {
-			if (d->next == dev) {
-				d->next = d->next->next;
-				break;
-			}
-			
-			d = d->next;
-		}
-	}
-	pthread_mutex_unlock(&device_list_mutex);
-
 	/* Free the structure itself. */
 	free(dev);
 }
 
-static 	IOHIDManagerRef hid_mgr = 0x0;
+static	IOHIDManagerRef hid_mgr = 0x0;
 
 
 #if 0
@@ -234,7 +191,7 @@ static int32_t get_int_property(IOHIDDeviceRef device, CFStringRef key)
 {
 	CFTypeRef ref;
 	int32_t value;
-	
+
 	ref = IOHIDDeviceGetProperty(device, key);
 	if (ref) {
 		if (CFGetTypeID(ref) == CFNumberGetTypeID()) {
@@ -255,6 +212,10 @@ static unsigned short get_product_id(IOHIDDeviceRef device)
 	return get_int_property(device, CFSTR(kIOHIDProductIDKey));
 }
 
+static int32_t get_location_id(IOHIDDeviceRef device)
+{
+	return get_int_property(device, CFSTR(kIOHIDLocationIDKey));
+}
 
 static int32_t get_max_report_length(IOHIDDeviceRef device)
 {
@@ -263,43 +224,66 @@ static int32_t get_max_report_length(IOHIDDeviceRef device)
 
 static int get_string_property(IOHIDDeviceRef device, CFStringRef prop, wchar_t *buf, size_t len)
 {
-	CFStringRef str = IOHIDDeviceGetProperty(device, prop);
+	CFStringRef str;
 
-	buf[0] = 0x0000;
+	if (!len)
+		return 0;
+
+	str = IOHIDDeviceGetProperty(device, prop);
+
+	buf[0] = 0;
 
 	if (str) {
+		CFIndex str_len = CFStringGetLength(str);
 		CFRange range;
-		range.location = 0;
-		range.length = len;
 		CFIndex used_buf_len;
-		CFStringGetBytes(str,
+		CFIndex chars_copied;
+
+		len --;
+
+		range.location = 0;
+		range.length = ((size_t)str_len > len)? len: (size_t)str_len;
+		chars_copied = CFStringGetBytes(str,
 			range,
 			kCFStringEncodingUTF32LE,
 			(char)'?',
 			FALSE,
 			(UInt8*)buf,
-			len,
+			len * sizeof(wchar_t),
 			&used_buf_len);
-		buf[len-1] = 0x00000000;
-		return used_buf_len;
+
+		if (chars_copied == len)
+			buf[len] = 0; /* len is decremented above */
+		else
+			buf[chars_copied] = 0;
+
+		return 0;
 	}
 	else
-		return 0;
-		
+		return -1;
+
 }
 
 static int get_string_property_utf8(IOHIDDeviceRef device, CFStringRef prop, char *buf, size_t len)
 {
-	CFStringRef str = IOHIDDeviceGetProperty(device, prop);
+	CFStringRef str;
+	if (!len)
+		return 0;
 
-	buf[0] = 0x0000;
+	str = IOHIDDeviceGetProperty(device, prop);
+
+	buf[0] = 0;
 
 	if (str) {
+		len--;
+
+		CFIndex str_len = CFStringGetLength(str);
 		CFRange range;
 		range.location = 0;
-		range.length = len;
+		range.length = str_len;
 		CFIndex used_buf_len;
-		CFStringGetBytes(str,
+		CFIndex chars_copied;
+		chars_copied = CFStringGetBytes(str,
 			range,
 			kCFStringEncodingUTF8,
 			(char)'?',
@@ -307,12 +291,16 @@ static int get_string_property_utf8(IOHIDDeviceRef device, CFStringRef prop, cha
 			(UInt8*)buf,
 			len,
 			&used_buf_len);
-		buf[len-1] = 0x00000000;
+
+		if (used_buf_len == len)
+			buf[len] = 0; /* len is decremented above */
+		else
+			buf[used_buf_len] = 0;
+
 		return used_buf_len;
 	}
 	else
 		return 0;
-		
 }
 
 
@@ -348,47 +336,53 @@ static int make_path(IOHIDDeviceRef device, char *buf, size_t len)
 	int res;
 	unsigned short vid, pid;
 	char transport[32];
+	int32_t location;
 
 	buf[0] = '\0';
 
 	res = get_string_property_utf8(
 		device, CFSTR(kIOHIDTransportKey),
 		transport, sizeof(transport));
-	
+
 	if (!res)
 		return -1;
 
+	location = get_location_id(device);
 	vid = get_vendor_id(device);
 	pid = get_product_id(device);
 
-	res = snprintf(buf, len, "%s_%04hx_%04hx_%p",
-	                   transport, vid, pid, device);
-	
-	
+	res = snprintf(buf, len, "%s_%04hx_%04hx_%x",
+                       transport, vid, pid, location);
+
+
 	buf[len-1] = '\0';
 	return res+1;
 }
 
+/* Initialize the IOHIDManager. Return 0 for success and -1 for failure. */
 static int init_hid_manager(void)
 {
-	IOReturn res;
-	
 	/* Initialize all the HID Manager Objects */
 	hid_mgr = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
-	IOHIDManagerSetDeviceMatching(hid_mgr, NULL);
-	IOHIDManagerScheduleWithRunLoop(hid_mgr, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
-	res = IOHIDManagerOpen(hid_mgr, kIOHIDOptionsTypeNone);
-	return (res == kIOReturnSuccess)? 0: -1;
+	if (hid_mgr) {
+		IOHIDManagerSetDeviceMatching(hid_mgr, NULL);
+		IOHIDManagerScheduleWithRunLoop(hid_mgr, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+		return 0;
+	}
+
+	return -1;
 }
 
+/* Initialize the IOHIDManager if necessary. This is the public function, and
+   it is safe to call this function repeatedly. Return 0 for success and -1
+   for failure. */
 int HID_API_EXPORT hid_init(void)
 {
 	if (!hid_mgr) {
-		if (init_hid_manager() < 0) {
-			hid_exit();
-			return -1;
-		}
+		return init_hid_manager();
 	}
+
+	/* Already initialized. */
 	return 0;
 }
 
@@ -400,31 +394,41 @@ int HID_API_EXPORT hid_exit(void)
 		CFRelease(hid_mgr);
 		hid_mgr = NULL;
 	}
-		
+
 	return 0;
+}
+
+static void process_pending_events(void) {
+	SInt32 res;
+	do {
+		res = CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.001, FALSE);
+	} while(res != kCFRunLoopRunFinished && res != kCFRunLoopRunTimedOut);
 }
 
 struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, unsigned short product_id)
 {
-	struct hid_device_info *root = NULL; // return object
+	struct hid_device_info *root = NULL; /* return object */
 	struct hid_device_info *cur_dev = NULL;
 	CFIndex num_devices;
 	int i;
-	
-	setlocale(LC_ALL,"");
 
 	/* Set up the HID Manager if it hasn't been done */
-	hid_init();
-	
+	if (hid_init() < 0)
+		return NULL;
+
+	/* give the IOHIDManager a chance to update itself */
+	process_pending_events();
+
 	/* Get a list of the Devices */
+	IOHIDManagerSetDeviceMatching(hid_mgr, NULL);
 	CFSetRef device_set = IOHIDManagerCopyDevices(hid_mgr);
 
-	/* Convert the list into a C array so we can iterate easily. */	
+	/* Convert the list into a C array so we can iterate easily. */
 	num_devices = CFSetGetCount(device_set);
 	IOHIDDeviceRef *device_array = calloc(num_devices, sizeof(IOHIDDeviceRef));
 	CFSetGetValues(device_set, (const void **) device_array);
 
-	/* Iterate over each device, making an entry for it. */	
+	/* Iterate over each device, making an entry for it. */
 	for (i = 0; i < num_devices; i++) {
 		unsigned short dev_vid;
 		unsigned short dev_pid;
@@ -441,12 +445,12 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 		dev_pid = get_product_id(dev);
 
 		/* Check the VID/PID against the arguments */
-		if ((vendor_id == 0x0 && product_id == 0x0) ||
-		    (vendor_id == dev_vid && product_id == dev_pid)) {
+		if ((vendor_id == 0x0 || vendor_id == dev_vid) &&
+		    (product_id == 0x0 || product_id == dev_pid)) {
 			struct hid_device_info *tmp;
 			size_t len;
 
-		    	/* VID/PID match. Create the record. */
+			/* VID/PID match. Create the record. */
 			tmp = malloc(sizeof(struct hid_device_info));
 			if (cur_dev) {
 				cur_dev->next = tmp;
@@ -456,7 +460,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 			}
 			cur_dev = tmp;
 
-			// Get the Usage Page and Usage for this device.
+			/* Get the Usage Page and Usage for this device. */
 			cur_dev->usage_page = get_int_property(dev, CFSTR(kIOHIDPrimaryUsagePageKey));
 			cur_dev->usage = get_int_property(dev, CFSTR(kIOHIDPrimaryUsageKey));
 
@@ -474,7 +478,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 			cur_dev->manufacturer_string = dup_wcs(buf);
 			get_product_string(dev, buf, BUF_LEN);
 			cur_dev->product_string = dup_wcs(buf);
-			
+
 			/* VID/PID */
 			cur_dev->vendor_id = dev_vid;
 			cur_dev->product_id = dev_pid;
@@ -486,10 +490,10 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 			cur_dev->interface_number = -1;
 		}
 	}
-	
+
 	free(device_array);
 	CFRelease(device_set);
-	
+
 	return root;
 }
 
@@ -514,7 +518,7 @@ hid_device * HID_API_EXPORT hid_open(unsigned short vendor_id, unsigned short pr
 	struct hid_device_info *devs, *cur_dev;
 	const char *path_to_open = NULL;
 	hid_device * handle = NULL;
-	
+
 	devs = hid_enumerate(vendor_id, product_id);
 	cur_dev = devs;
 	while (cur_dev) {
@@ -540,25 +544,18 @@ hid_device * HID_API_EXPORT hid_open(unsigned short vendor_id, unsigned short pr
 	}
 
 	hid_free_enumeration(devs);
-	
+
 	return handle;
 }
 
 static void hid_device_removal_callback(void *context, IOReturn result,
-                                        void *sender, IOHIDDeviceRef dev_ref)
+                                        void *sender)
 {
 	/* Stop the Run Loop for this device. */
-	pthread_mutex_lock(&device_list_mutex);
-	hid_device *d = device_list;
-	while (d) {
-		if (d->device_handle == dev_ref) {
-			d->disconnected = 1;
-			CFRunLoopStop(d->run_loop);
-		}
-		
-		d = d->next;
-	}
-	pthread_mutex_unlock(&device_list_mutex);
+	hid_device *d = context;
+
+	d->disconnected = 1;
+	CFRunLoopStop(d->run_loop);
 }
 
 /* The Run Loop calls this function for each input report received.
@@ -580,7 +577,7 @@ static void hid_report_callback(void *context, IOReturn result, void *sender,
 
 	/* Lock this section */
 	pthread_mutex_lock(&dev->mutex);
-	
+
 	/* Attach the new report object to the end of the list. */
 	if (dev->input_reports == NULL) {
 		/* The list is empty. Put it at the root. */
@@ -617,13 +614,14 @@ static void hid_report_callback(void *context, IOReturn result, void *sender,
 static void perform_signal_callback(void *context)
 {
 	hid_device *dev = context;
-	CFRunLoopStop(dev->run_loop); //TODO: CFRunLoopGetCurrent()
+	CFRunLoopStop(dev->run_loop); /*TODO: CFRunLoopGetCurrent()*/
 }
 
 static void *read_thread(void *param)
 {
 	hid_device *dev = param;
-	
+	SInt32 code;
+
 	/* Move the device's run loop to this thread. */
 	IOHIDDeviceScheduleWithRunLoop(dev->device_handle, CFRunLoopGetCurrent(), dev->run_loop_mode);
 
@@ -636,7 +634,7 @@ static void *read_thread(void *param)
 	ctx.perform = &perform_signal_callback;
 	dev->source = CFRunLoopSourceCreate(kCFAllocatorDefault, 0/*order*/, &ctx);
 	CFRunLoopAddSource(CFRunLoopGetCurrent(), dev->source, dev->run_loop_mode);
-	
+
 	/* Store off the Run Loop so it can be stopped from hid_close()
 	   and on device disconnection. */
 	dev->run_loop = CFRunLoopGetCurrent();
@@ -646,7 +644,6 @@ static void *read_thread(void *param)
 
 	/* Run the Event Loop. CFRunLoopRunInMode() will dispatch HID input
 	   reports into the hid_report_callback(). */
-	SInt32 code;
 	while (!dev->shutdown_thread && !dev->disconnected) {
 		code = CFRunLoopRunInMode(dev->run_loop_mode, 1000/*sec*/, FALSE);
 		/* Return if the device has been disconnected */
@@ -676,13 +673,6 @@ static void *read_thread(void *param)
 	pthread_cond_broadcast(&dev->condition);
 	pthread_mutex_unlock(&dev->mutex);
 
-	/* Close the OS handle to the device, but only if it's not
-	   been unplugged. If it's been unplugged, then calling
-	   IOHIDDeviceClose() will crash. */
-	if (!dev->disconnected) {
-		IOHIDDeviceClose(dev->device_handle, kIOHIDOptionsTypeNone);
-	}
-	
 	/* Wait here until hid_close() is called and makes it past
 	   the call to CFRunLoopWakeUp(). This thread still needs to
 	   be valid when that function is called on the other thread. */
@@ -693,58 +683,63 @@ static void *read_thread(void *param)
 
 hid_device * HID_API_EXPORT hid_open_path(const char *path)
 {
-  	int i;
+	int i;
 	hid_device *dev = NULL;
 	CFIndex num_devices;
-	
+
 	dev = new_hid_device();
 
 	/* Set up the HID Manager if it hasn't been done */
-	hid_init();
+	if (hid_init() < 0)
+		return NULL;
+
+	/* give the IOHIDManager a chance to update itself */
+	process_pending_events();
 
 	CFSetRef device_set = IOHIDManagerCopyDevices(hid_mgr);
-	
+
 	num_devices = CFSetGetCount(device_set);
 	IOHIDDeviceRef *device_array = calloc(num_devices, sizeof(IOHIDDeviceRef));
-	CFSetGetValues(device_set, (const void **) device_array);	
+	CFSetGetValues(device_set, (const void **) device_array);
 	for (i = 0; i < num_devices; i++) {
 		char cbuf[BUF_LEN];
 		size_t len;
 		IOHIDDeviceRef os_dev = device_array[i];
-		
+
 		len = make_path(os_dev, cbuf, sizeof(cbuf));
 		if (!strcmp(cbuf, path)) {
-			// Matched Paths. Open this Device.
-			IOReturn ret = IOHIDDeviceOpen(os_dev, kIOHIDOptionsTypeNone);
+			/* Matched Paths. Open this Device. */
+			IOReturn ret = IOHIDDeviceOpen(os_dev, kIOHIDOptionsTypeSeizeDevice);
 			if (ret == kIOReturnSuccess) {
 				char str[32];
 
 				free(device_array);
+				CFRetain(os_dev);
 				CFRelease(device_set);
 				dev->device_handle = os_dev;
-				
+
 				/* Create the buffers for receiving data */
 				dev->max_input_report_len = (CFIndex) get_max_report_length(os_dev);
 				dev->input_report_buf = calloc(dev->max_input_report_len, sizeof(uint8_t));
-				
+
 				/* Create the Run Loop Mode for this device.
 				   printing the reference seems to work. */
 				sprintf(str, "HIDAPI_%p", os_dev);
-				dev->run_loop_mode = 
+				dev->run_loop_mode =
 					CFStringCreateWithCString(NULL, str, kCFStringEncodingASCII);
-				
+
 				/* Attach the device to a Run Loop */
 				IOHIDDeviceRegisterInputReportCallback(
 					os_dev, dev->input_report_buf, dev->max_input_report_len,
 					&hid_report_callback, dev);
-				IOHIDManagerRegisterDeviceRemovalCallback(hid_mgr, hid_device_removal_callback, NULL);
-				
+				IOHIDDeviceRegisterRemovalCallback(dev->device_handle, hid_device_removal_callback, dev);
+
 				/* Start the read thread */
 				pthread_create(&dev->thread, NULL, read_thread, dev);
 
 				/* Wait here for the read thread to be initialized. */
 				pthread_barrier_wait(&dev->barrier);
-				
+
 				return dev;
 			}
 			else {
@@ -767,8 +762,8 @@ static int set_report(hid_device *dev, IOHIDReportType type, const unsigned char
 	IOReturn res;
 
 	/* Return if the device has been disconnected. */
-   	if (dev->disconnected)
-   		return -1;
+	if (dev->disconnected)
+		return -1;
 
 	if (data[0] == 0x0) {
 		/* Not using numbered Reports.
@@ -782,20 +777,20 @@ static int set_report(hid_device *dev, IOHIDReportType type, const unsigned char
 		data_to_send = data;
 		length_to_send = length;
 	}
-	
+
 	if (!dev->disconnected) {
 		res = IOHIDDeviceSetReport(dev->device_handle,
 					   type,
 					   data[0], /* Report ID*/
 					   data_to_send, length_to_send);
-	
+
 		if (res == kIOReturnSuccess) {
 			return length;
 		}
 		else
 			return -1;
 	}
-	
+
 	return -1;
 }
 
@@ -830,11 +825,11 @@ static int cond_wait(const hid_device *dev, pthread_cond_t *cond, pthread_mutex_
 		   data in the queue before returning, and if not, go back
 		   to sleep. See the pthread_cond_timedwait() man page for
 		   details. */
-		
+
 		if (dev->shutdown_thread || dev->disconnected)
 			return -1;
 	}
-	
+
 	return 0;
 }
 
@@ -850,11 +845,11 @@ static int cond_timedwait(const hid_device *dev, pthread_cond_t *cond, pthread_m
 		   data in the queue before returning, and if not, go back
 		   to sleep. See the pthread_cond_timedwait() man page for
 		   details. */
-		
+
 		if (dev->shutdown_thread || dev->disconnected)
 			return -1;
 	}
-	
+
 	return 0;
 
 }
@@ -865,7 +860,7 @@ int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t
 
 	/* Lock the access to the report list. */
 	pthread_mutex_lock(&dev->mutex);
-	
+
 	/* There's an input report queued up. Return it. */
 	if (dev->input_reports) {
 		/* Return the first one */
@@ -878,7 +873,7 @@ int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t
 		bytes_read = -1;
 		goto ret;
 	}
-	
+
 	if (dev->shutdown_thread) {
 		/* This means the device has been closed (or there
 		   has been an error. An error code of -1 should
@@ -888,7 +883,7 @@ int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t
 	}
 
 	/* There is no data. Go to sleep and wait for data. */
-	
+
 	if (milliseconds == -1) {
 		/* Blocking */
 		int res;
@@ -913,7 +908,7 @@ int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t
 			ts.tv_sec++;
 			ts.tv_nsec -= 1000000000L;
 		}
-		
+
 		res = cond_timedwait(dev, &dev->condition, &dev->mutex, &ts);
 		if (res == 0)
 			bytes_read = return_data(dev, data, length);
@@ -942,7 +937,7 @@ int HID_API_EXPORT hid_set_nonblocking(hid_device *dev, int nonblock)
 {
 	/* All Nonblocking operation is handled by the library. */
 	dev->blocking = !nonblock;
-	
+
 	return 0;
 }
 
@@ -981,18 +976,18 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 		IOHIDDeviceRegisterInputReportCallback(
 			dev->device_handle, dev->input_report_buf, dev->max_input_report_len,
 			NULL, dev);
-		IOHIDManagerRegisterDeviceRemovalCallback(hid_mgr, NULL, dev);
+		IOHIDDeviceRegisterRemovalCallback(dev->device_handle, NULL, dev);
 		IOHIDDeviceUnscheduleFromRunLoop(dev->device_handle, dev->run_loop, dev->run_loop_mode);
 		IOHIDDeviceScheduleWithRunLoop(dev->device_handle, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
 	}
-	
+
 	/* Cause read_thread() to stop. */
 	dev->shutdown_thread = 1;
-	
+
 	/* Wake up the run thread's event loop so that the thread can exit. */
 	CFRunLoopSourceSignal(dev->source);
 	CFRunLoopWakeUp(dev->run_loop);
-	
+
 	/* Notify the read thread that it can shut down now. */
 	pthread_barrier_wait(&dev->shutdown_barrier);
 
@@ -1003,15 +998,16 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 	   been unplugged. If it's been unplugged, then calling
 	   IOHIDDeviceClose() will crash. */
 	if (!dev->disconnected) {
-		IOHIDDeviceClose(dev->device_handle, kIOHIDOptionsTypeNone);
+		IOHIDDeviceClose(dev->device_handle, kIOHIDOptionsTypeSeizeDevice);
 	}
-	
+
 	/* Clear out the queue of received reports. */
 	pthread_mutex_lock(&dev->mutex);
 	while (dev->input_reports) {
 		return_data(dev, NULL, 0);
 	}
 	pthread_mutex_unlock(&dev->mutex);
+	CFRelease(dev->device_handle);
 
 	free_hid_device(dev);
 }
@@ -1033,7 +1029,7 @@ int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *s
 
 int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index, wchar_t *string, size_t maxlen)
 {
-	// TODO:
+	/* TODO: */
 
 	return 0;
 }
@@ -1041,7 +1037,7 @@ int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index
 
 HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
 {
-	// TODO:
+	/* TODO: */
 
 	return NULL;
 }
@@ -1051,12 +1047,8 @@ HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
 
 
 
-#if 0
-static int32_t get_location_id(IOHIDDeviceRef device)
-{
-	return get_int_property(device, CFSTR(kIOHIDLocationIDKey));
-}
 
+#if 0
 static int32_t get_usage(IOHIDDeviceRef device)
 {
 	int32_t res;
@@ -1085,19 +1077,17 @@ int main(void)
 {
 	IOHIDManagerRef mgr;
 	int i;
-	
+
 	mgr = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
 	IOHIDManagerSetDeviceMatching(mgr, NULL);
 	IOHIDManagerOpen(mgr, kIOHIDOptionsTypeNone);
-	
+
 	CFSetRef device_set = IOHIDManagerCopyDevices(mgr);
-	
+
 	CFIndex num_devices = CFSetGetCount(device_set);
 	IOHIDDeviceRef *device_array = calloc(num_devices, sizeof(IOHIDDeviceRef));
 	CFSetGetValues(device_set, (const void **) device_array);
-	
-	setlocale(LC_ALL, "");
-	
+
 	for (i = 0; i < num_devices; i++) {
 		IOHIDDeviceRef dev = device_array[i];
 		printf("Device: %p\n", dev);
@@ -1107,16 +1097,16 @@ int main(void)
 		char cbuf[256];
 		get_serial_number(dev, serial, 256);
 
-		
+
 		printf("  Serial: %ls\n", serial);
 		printf("  Loc: %ld\n", get_location_id(dev));
 		get_transport(dev, buf, 256);
 		printf("  Trans: %ls\n", buf);
 		make_path(dev, cbuf, 256);
 		printf("  Path: %s\n", cbuf);
-		
+
 	}
-	
+
 	return 0;
 }
 #endif


### PR DESCRIPTION
So my FDSStick came today (yay), but when I tried to compile and run the tool, I had two problems.

First, it wouldn't build.  That was easy to fix, by adding 'static' to that one function declaration so that it matched the definition, and then by adding the -liconv since that library was being referenced in the code.

Second, it segfaulted on startup.  The specific problem is that I was getting kIOReturnExclusiveAccess as an error on IOHIDManagerOpen.  I couldn't figure out why, so I just went to hidlib's git, grabbed the newest Mac code, and bam, it just worked™.

I know it worked because it built, ran, and I was able to write a disk image to my new FDSStick, and it ran.