### PR TITLE
Add pthread as a library for Linux targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ifeq ($(UNAME),Darwin)
 endif
 ifeq ($(UNAME),Linux)
  COBJS    = hidapi/hid-linux.o
- LIBS      = `pkg-config libusb-1.0 --libs`
+ LIBS      = `pkg-config libusb-1.0 --libs` -l pthread
  INCLUDES ?= `pkg-config libusb-1.0 --cflags`
 endif
 OBJS      = $(COBJS) $(CPPOBJS)


### PR DESCRIPTION
Fails to compile on Linux (Debian Jessie x64) due to missing pthread library.

/usr/bin/ld: hidapi/hid-linux.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:24: recipe for target 'fds' failed
make: *** [fds] Error 1